### PR TITLE
🌱 Add Python project structure — CLI for agent task management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ __pycache__/
 .DS_Store
 *.log
 docs/
+__pycache__/
+*.pyc
+.pytest_cache/
+dist/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "slop-farm"
+version = "0.1.0"
+description = "Agent-governed task farming — autonomous AI agents grow work"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+dependencies = ["httpx>=0.27", "rich>=13"]
+
+[project.scripts]
+slop = "slop_farm.cli:main"
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-asyncio>=0.24", "mypy>=1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Agent-governed task farming — autonomous AI agents grow work"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
-dependencies = ["httpx>=0.27", "rich>=13"]
+dependencies = ["rich>=13"]
 
 [project.scripts]
 slop = "slop_farm.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "slop-farm"
 version = "0.1.0"
-description = "Agent-governed task farming — autonomous AI agents grow work"
+description = "Agent-governed task farming — persistent task management with JSON state"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/src/slop_farm/__init__.py
+++ b/src/slop_farm/__init__.py
@@ -1,0 +1,2 @@
+"""slop-farm: Agent-governed task farming."""
+__version__ = "0.1.0"

--- a/src/slop_farm/cli.py
+++ b/src/slop_farm/cli.py
@@ -1,31 +1,117 @@
-"""CLI interface for slop-farm agent task management."""
+"""CLI interface for slop-farm — persistent agent task management."""
 
 import argparse
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 
 console = Console()
 
+STATE_FILE = Path(os.environ.get("SLOP_STATE", str(Path.home() / ".slop-farm" / "tasks.json")))
+
+def load_state() -> dict:
+    """Load task state from JSON file."""
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {"tasks": [], "version": 1}
+
+def save_state(state: dict) -> None:
+    """Persist task state to JSON file."""
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2, default=str))
+
 def cmd_status():
-    """Show farm status."""
+    """Show farm status reading from real state."""
+    state = load_state()
+    tasks = state.get("tasks", [])
+    pending = [t for t in tasks if t["status"] == "pending"]
+    done = [t for t in tasks if t["status"] == "done"]
+
     table = Table(title="🌱 slop-farm Status")
     table.add_column("Metric", style="cyan")
     table.add_column("Value", style="green")
-    table.add_row("Version", "0.1.0")
-    table.add_row("Agents active", "0")
-    table.add_row("PRs open", "0")
-    table.add_row("Reviews pending", "0")
+    table.add_row("Tasks pending", str(len(pending)))
+    table.add_row("Tasks done", str(len(done)))
+    table.add_row("State file", str(STATE_FILE))
     console.print(table)
 
-def cmd_plant(task: str):
-    """Plant a new task for agents."""
-    console.print(f"[green]🌱 Planted task:[/green] {task}")
-    console.print("[dim]Agents will discover and work on this task.[/dim]")
+    if pending:
+        console.print("\n[bold]Pending tasks:[/bold]")
+        for t in pending[:10]:
+            console.print(f"  [yellow]●[/yellow] {t['id'][:8]} — {t['description'][:60]} ({t['created_at'][:10]})")
+
+def cmd_plant(task_desc: str):
+    """Plant a new task — persists to state."""
+    state = load_state()
+    task = {
+        "id": str(uuid.uuid4()),
+        "description": task_desc,
+        "status": "pending",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    state["tasks"].append(task)
+    save_state(state)
+    console.print(f"[green]🌱 Planted:[/green] {task['id'][:8]} — {task_desc}")
 
 def cmd_harvest():
-    """Harvest completed work."""
-    console.print("[yellow]🌾 Harvesting completed tasks...[/yellow]")
-    console.print("[green]✓ No ripe tasks to harvest.[/green]")
+    """Harvest completed tasks — reads from state."""
+    state = load_state()
+    done = [t for t in state["tasks"] if t["status"] == "done"]
+    pending = [t for t in state["tasks"] if t["status"] == "pending"]
+
+    if not pending and not done:
+        console.print("[dim]No tasks in the farm yet. Plant one with: slop plant <task>[/dim]")
+        return
+
+    if not done:
+        console.print(f"[yellow]🌾 {len(pending)} tasks pending, none ready to harvest.[/yellow]")
+        return
+
+    console.print(f"[green]🌾 Harvesting {len(done)} completed task(s):[/green]")
+    for t in done:
+        console.print(f"  ✓ {t['id'][:8]} — {t['description'][:60]}")
+        t["status"] = "archived"
+
+    # Clean archived from active list after harvest
+    state["tasks"] = [t for t in state["tasks"] if t["status"] != "archived"]
+    save_state(state)
+
+def cmd_done(task_id: str):
+    """Mark a task as done."""
+    state = load_state()
+    for t in state["tasks"]:
+        if t["id"].startswith(task_id):
+            t["status"] = "done"
+            save_state(state)
+            console.print(f"[green]✓ Task {task_id} marked as done[/green]")
+            return
+    console.print(f"[red]Task {task_id} not found[/red]")
+
+def cmd_list():
+    """List all tasks."""
+    state = load_state()
+    tasks = state.get("tasks", [])
+    if not tasks:
+        console.print("[dim]No tasks yet.[/dim]")
+        return
+    table = Table(title="📋 Tasks")
+    table.add_column("ID", style="dim")
+    table.add_column("Status")
+    table.add_column("Description")
+    table.add_column("Created")
+    for t in tasks:
+        icon = "⏳" if t["status"] == "pending" else "✓"
+        color = "yellow" if t["status"] == "pending" else "green"
+        table.add_row(t["id"][:8], f"[{color}]{icon} {t['status']}[/{color}]", 
+                      t["description"][:50], t["created_at"][:10])
+    console.print(table)
 
 def main():
     parser = argparse.ArgumentParser(description="slop-farm — agent-governed task farming")
@@ -37,6 +123,10 @@ def main():
     plant.add_argument("task", help="Task description")
     
     sub.add_parser("harvest", help="Harvest completed tasks")
+    sub.add_parser("list", help="List all tasks")
+
+    done = sub.add_parser("done", help="Mark task as done")
+    done.add_argument("task_id", help="Task ID (first 8 chars enough)")
 
     args = parser.parse_args()
     
@@ -46,6 +136,10 @@ def main():
         cmd_plant(args.task)
     elif args.command == "harvest":
         cmd_harvest()
+    elif args.command == "list":
+        cmd_list()
+    elif args.command == "done":
+        cmd_done(args.task_id)
     else:
         parser.print_help()
 

--- a/src/slop_farm/cli.py
+++ b/src/slop_farm/cli.py
@@ -1,0 +1,53 @@
+"""CLI interface for slop-farm agent task management."""
+
+import argparse
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+def cmd_status():
+    """Show farm status."""
+    table = Table(title="🌱 slop-farm Status")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="green")
+    table.add_row("Version", "0.1.0")
+    table.add_row("Agents active", "0")
+    table.add_row("PRs open", "0")
+    table.add_row("Reviews pending", "0")
+    console.print(table)
+
+def cmd_plant(task: str):
+    """Plant a new task for agents."""
+    console.print(f"[green]🌱 Planted task:[/green] {task}")
+    console.print("[dim]Agents will discover and work on this task.[/dim]")
+
+def cmd_harvest():
+    """Harvest completed work."""
+    console.print("[yellow]🌾 Harvesting completed tasks...[/yellow]")
+    console.print("[green]✓ No ripe tasks to harvest.[/green]")
+
+def main():
+    parser = argparse.ArgumentParser(description="slop-farm — agent-governed task farming")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("status", help="Show farm status")
+    
+    plant = sub.add_parser("plant", help="Plant a new task")
+    plant.add_argument("task", help="Task description")
+    
+    sub.add_parser("harvest", help="Harvest completed tasks")
+
+    args = parser.parse_args()
+    
+    if args.command == "status":
+        cmd_status()
+    elif args.command == "plant":
+        cmd_plant(args.task)
+    elif args.command == "harvest":
+        cmd_harvest()
+    else:
+        parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,19 @@
+"""Tests for slop-farm CLI."""
+
+import subprocess
+import sys
+
+def test_import():
+    from slop_farm import __version__
+    assert __version__ == "0.1.0"
+
+def test_cli_status():
+    result = subprocess.run([sys.executable, "-m", "slop_farm.cli", "status"], 
+                          capture_output=True, text=True)
+    assert result.returncode == 0
+
+def test_cli_help():
+    result = subprocess.run([sys.executable, "-m", "slop_farm.cli", "--help"],
+                          capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "slop-farm" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,19 +1,122 @@
-"""Tests for slop-farm CLI."""
+"""Tests for slop-farm CLI with real state assertions."""
 
+import json
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
+
+CLI = [sys.executable, "-m", "slop_farm.cli"]
+
+
+def run_slop(*args, env=None):
+    return subprocess.run([*CLI, *args], capture_output=True, text=True, env=env)
+
 
 def test_import():
     from slop_farm import __version__
     assert __version__ == "0.1.0"
 
-def test_cli_status():
-    result = subprocess.run([sys.executable, "-m", "slop_farm.cli", "status"], 
-                          capture_output=True, text=True)
+
+def test_status_empty():
+    result = run_slop("status")
     assert result.returncode == 0
 
-def test_cli_help():
-    result = subprocess.run([sys.executable, "-m", "slop_farm.cli", "--help"],
-                          capture_output=True, text=True)
-    assert result.returncode == 0
-    assert "slop-farm" in result.stdout
+
+def test_plant_creates_state_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        state_file = Path(tmp) / "tasks.json"
+        env = {**__import__("os").environ, "SLOP_STATE": str(state_file)}
+        
+        result = run_slop("plant", "test task", env=env)
+        assert result.returncode == 0
+        assert "test task" in result.stdout
+        assert state_file.exists()
+        
+        data = json.loads(state_file.read_text())
+        assert len(data["tasks"]) == 1
+        assert data["tasks"][0]["description"] == "test task"
+        assert data["tasks"][0]["status"] == "pending"
+        assert "id" in data["tasks"][0]
+        assert "created_at" in data["tasks"][0]
+
+
+def test_status_shows_task():
+    with tempfile.TemporaryDirectory() as tmp:
+        state_file = Path(tmp) / "tasks.json"
+        env = {**__import__("os").environ, "SLOP_STATE": str(state_file)}
+        
+        run_slop("plant", "my important task", env=env)
+        result = run_slop("status", env=env)
+        assert result.returncode == 0
+        assert "my important task" in result.stdout
+        assert "Tasks pending" in result.stdout
+
+
+def test_done_marks_task():
+    with tempfile.TemporaryDirectory() as tmp:
+        state_file = Path(tmp) / "tasks.json"
+        env = {**__import__("os").environ, "SLOP_STATE": str(state_file)}
+        
+        plant = run_slop("plant", "do this thing", env=env)
+        data = json.loads(state_file.read_text())
+        task_id = data["tasks"][0]["id"][:8]
+        
+        result = run_slop("done", task_id, env=env)
+        assert result.returncode == 0
+        
+        data = json.loads(state_file.read_text())
+        assert data["tasks"][0]["status"] == "done"
+
+
+def test_harvest_archives_done_tasks():
+    with tempfile.TemporaryDirectory() as tmp:
+        state_file = Path(tmp) / "tasks.json"
+        env = {**__import__("os").environ, "SLOP_STATE": str(state_file)}
+        
+        run_slop("plant", "task one", env=env)
+        run_slop("plant", "task two", env=env)
+        data = json.loads(state_file.read_text())
+        tid = data["tasks"][0]["id"][:8]
+        run_slop("done", tid, env=env)
+        
+        result = run_slop("harvest", env=env)
+        assert result.returncode == 0
+        
+        data = json.loads(state_file.read_text())
+        assert len(data["tasks"]) == 1  # done+archived removed, pending stays
+        assert data["tasks"][0]["status"] == "pending"
+
+
+def test_list_shows_tasks():
+    with tempfile.TemporaryDirectory() as tmp:
+        state_file = Path(tmp) / "tasks.json"
+        env = {**__import__("os").environ, "SLOP_STATE": str(state_file)}
+        
+        run_slop("plant", "alpha", env=env)
+        run_slop("plant", "beta", env=env)
+        result = run_slop("list", env=env)
+        assert result.returncode == 0
+        assert "alpha" in result.stdout
+        assert "beta" in result.stdout
+
+
+def test_plant_with_special_chars():
+    with tempfile.TemporaryDirectory() as tmp:
+        state_file = Path(tmp) / "tasks.json"
+        env = {**__import__("os").environ, "SLOP_STATE": str(state_file)}
+        
+        result = run_slop("plant", "task with 'quotes' and \"double\"", env=env)
+        assert result.returncode == 0
+        data = json.loads(state_file.read_text())
+        assert "quotes" in data["tasks"][0]["description"]
+
+
+def test_empty_harvest():
+    with tempfile.TemporaryDirectory() as tmp:
+        state_file = Path(tmp) / "tasks.json"
+        env = {**__import__("os").environ, "SLOP_STATE": str(state_file)}
+        
+        result = run_slop("harvest", env=env)
+        assert result.returncode == 0
+


### PR DESCRIPTION
## What

First code contribution to slop-farm — a Python CLI for autonomous agent task farming.

## Changes

- `pyproject.toml` — hatchling build, httpx + rich deps, CLI entry point
- `src/slop_farm/cli.py` — three commands: `status`, `plant <task>`, `harvest`
- `tests/test_cli.py` — import + CLI tests
- `.gitignore` — Python artifacts

## Why

Sets the foundation for agent-governed task management. Agents can plant tasks, harvest completed work, and check farm status.

## Test

```bash
pip install -e .
slop status
slop plant "Review incoming PRs"
slop harvest
pytest tests/
```

Closes #1